### PR TITLE
Pipeline Exception Catching for Extractor

### DIFF
--- a/dltpy/preprocessing/pipeline.py
+++ b/dltpy/preprocessing/pipeline.py
@@ -157,6 +157,12 @@ class Pipeline:
                     print(f"Could not parse file {filename}")
                 except UnicodeDecodeError:
                     print(f"Could not read file {filename}")
+                except:
+                    # Other unexpected exceptions; Failure of single file should not
+                    # fail the entire project processing.
+                    # TODO: A better workaround would be to have a specialized exception thrown
+                    # by the extractor, so that this exception is specialized.
+                    print(f"Could not process file {filename}")
 
             print(f'Preprocessing for {project_id}...')
             preprocessed_functions = {}


### PR DESCRIPTION
Currently, the entire project will fail processing if one file fails to process in the pipeline. To extract more data, we should consider catching exceptions on the file, and let the project parsing continue.

For instance, some projects might have artifact files that cause the extractor to fail, but are otherwise projects that are completely valid apart from those artifact files.

The small fix will catch these exceptions and skip the files. It can be improved upon in the future from the code side, but will do for now.